### PR TITLE
Add styling to app

### DIFF
--- a/client/main.css
+++ b/client/main.css
@@ -1,124 +1,181 @@
-body {
-  font-family: sans-serif;
-  background-color: #315481;
-  background-image: linear-gradient(to bottom, #315481, #918e82 100%);
-  background-attachment: fixed;
+:root {
+  --action-button-press: 70%;
+  --border-radius-circle: 9999rem;
+  --color-white: #FFFFFF;
+  --color-black: #291D1F;
+  --color-theme: #097EAE;
+  --color-add: #05875C;
+  --color-delete: #BC1319;
+  --color-divider-category: #888888;
+  --color-divider-grocery-item: #EBEBEB;
+  --font-family-primary: sans-serif;
+  --font-size-1: 1rem;
+  --font-size-2: 1.2rem;
+  --font-size-3: 1.3rem;
+  --font-size-4: 1.4rem;
+  --gap: 0.5rem;
+  --gutter: 1rem;
+  --line-height-1: 1;
+  --line-height-2: 1.2;
+  --line-height-3: 1.3;
+  --line-height-4: 1.4;
+  --tracking-tight: -0.5px;
+}
 
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-
-  padding: 0;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
   margin: 0;
+  padding: 0;
+}
 
-  font-size: 14px;
+
+/* Core */
+html {
+  margin: 0;
+  min-height: 100%;
+  overflow-y: scroll;
+  padding: 0;
+  text-size-adjust: 100%;
+
+  -ms-overflow-style: scrollbar;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  background-color: var(--color-white);
+  color: var(--color-black);
+  font-family: var(--font-family-primary);
+  font-size: 130%;
+  line-height: var(--line-height-3);
+  min-height: 100%;
+}
+
+/* Overall app layout */
+.main {
+  margin: calc(var(--gutter) * 2) var(--gutter) calc(var(--gutter) * 8) var(--gutter);
+}
+
+/* Utilities */
+.margin-bottom-tiny {
+  margin-bottom: 0.5rem;
+}
+
+.margin-bottom-small {
+  margin-bottom: 1rem;
+}
+
+.margin-bottom-medium {
+  margin-bottom: 2rem;
+}
+
+.margin-bottom-large {
+  margin-bottom: 3rem;
+}
+
+
+/* Base styling */
+h1,
+h2 {
+  line-height: var(--line-height-1);
+}
+
+input[type="text"] {
+  border: 1px solid var(--color-black);
+  font-size: var(--font-size-2);
+  line-height: var(--line-height-2);
+  padding: 1rem 0.75rem;
+  width: 100%;
 }
 
 button {
-  font-weight: bold;
-  font-size: 1em;
   border: none;
-  color: white;
-  box-shadow: 0 3px 3px rgba(34, 25, 25, 0.4);
-  padding: 5px;
-  cursor: pointer;
+  color: var(--color-white);
 }
 
-button:focus {
-  outline: 0;
-}
 
-.app {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-}
-
-.app-header {
-  flex-grow: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.main {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  overflow: auto;
-  background: white;
-}
-
-.main::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-  background: inherit;
-}
-
-header {
-  background: #d2edf4;
-  background-image: linear-gradient(to bottom, #d0edf5, #e1e5f0 100%);
-  padding: 20px 15px 15px 15px;
-  position: relative;
-  box-shadow: 0 3px 3px rgba(34, 25, 25, 0.4);
-}
-
+/* App header */
 .app-bar {
+  background-color: var(--color-theme);
+  color: #fff;
+  padding: 1rem;
+}
+
+/* Titles */
+.title-app,
+.title-category {
+  letter-spacing: var(--tracking-tight);
+}
+
+.divider {
+  border-top: 1px dashed var(--color-divider-category);
+  padding-top: 1rem;
+  margin-top: 3rem;
+}
+
+
+/* Wrappers */
+.wrapper-input {
   display: flex;
-  justify-content: space-between;
+  gap: var(--gap);
 }
 
-.app-bar h1 {
-  font-size: 1.5em;
-  margin: 0;
-  display: inline-block;
-  margin-right: 1em;
+/* Buttons */
+.button-add:active,
+.button-delete:active,
+.button-completed:active {
+  filter: brightness(var(--action-button-press)); /* Adds a pressed effect */
 }
 
-.category-form {
+.button-add {
+  background-color: var(--color-add);
+}
+
+.button-add:active {
+  padding-top: 0.25rem;
+}
+
+.button-delete {
+  --button-delete-size: 1.5rem;
+
+  background-color: var(--color-delete);
+  border-radius: var(--border-radius-circle);
   display: flex;
-  margin: 16px;
+  align-items: center;
+  justify-content: center;
+  height: var(--button-delete-size);
+  margin-top: 0.25rem;
+  width: var(--button-delete-size);
 }
 
-.category-form > input {
-  flex-grow: 1;
-  box-sizing: border-box;
-  padding: 10px 6px;
-  background: transparent;
-  border: 1px solid #aaa;
-  width: 100%;
-  font-size: 1em;
-  margin-right: 16px;
+.button-delete svg {
+  --button-delete-icon-size: 0.75rem;
+
+  height: var(--button-delete-icon-size);
+  width: var(--button-delete-icon-size);
 }
 
-.category-form > input:focus {
-  outline: 0;
+.button-completed {
+  --button-completed-size: 1.75rem;
+
+  background-color: var(--color-add);
+  border-radius: var(--border-radius-circle);
+  height: var(--button-completed-size);
+  width: var(--button-completed-size);
 }
 
-.category-form > button {
-  min-width: 100px;
-  height: 95%;
-  background-color: #315481;
+
+/* Grocery items */
+.grocery-list {
+  margin-left: calc(var(--gutter) * 1.25);
 }
 
-.categories {
-  list-style-type: none;
-  padding-inline-start: 0;
-  padding-left: 16px;
-  padding-right: 16px;
-  margin-block-start: 0;
-  margin-block-end: 0;
-}
-
-.categories > h2 {
+.grocery-list-item {
+  border-bottom: 1px solid var(--color-divider-grocery-item);
   display: flex;
-  padding: 16px;
-  border-bottom: #eee solid 1px;
-}
-
-.categories > button {
-  justify-self: flex-end;
-  background-color: #ff3046;
+  gap: var(--gap);
+  justify-content: space-between; /* Aligns close buttons to the right side of the viewport in a tidy column */
+  padding: 0.75rem 0;
 }

--- a/imports/ui/App.svelte
+++ b/imports/ui/App.svelte
@@ -27,8 +27,8 @@ Meteor.call("categories.removeAll");
   <header>
     <div class="app-bar">
       <div class="app-header">
-        <h1>📝️ Shoppingbottom</h1>
-        <button class="delete" on:click={deleteEverything}>Clear List ⚡💣☠️⛔🚫</button>   
+        <h1 class="title-app">📝️ Shoppingbottom</h1>
+        <!-- <button type="button" class="delete" on:click={deleteEverything}>Clear List ⚡💣☠️⛔🚫</button> -->
       </div>
     </div>
   </header>

--- a/imports/ui/Category.svelte
+++ b/imports/ui/Category.svelte
@@ -13,12 +13,16 @@
       Meteor.call('categories.deleteGrocery', category._Id, deletedGgrocery);
    }
    </script>
-<h2> { category.text }</h2>
-<button class="delete" on:click={deleteThisCategory} aria-label="Delete category { category.text }">&times;</button>
+<div class="wrapper-input divider">
+   <h2 class="title-category margin-bottom-tiny">{ category.text }</h2>
+   <button class="button-delete" on:click={deleteThisCategory} aria-label="Delete category { category.text }">
+      <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" width="16" height="16" fill="none"><path fill="#fff" d="M7.2 5.8c.4.4.4 1 0 1.4-.2.2-.5.3-.7.3-.2 0-.5-.1-.7-.3L4 5.4 2.2 7.2c-.2.2-.5.3-.7.3-.2 0-.5-.1-.7-.3-.4-.4-.4-1 0-1.4L2.6 4 .8 2.2C.4 1.8.4 1.2.8.8c.4-.4 1-.4 1.4 0L4 2.6 5.8.8c.4-.4 1-.4 1.4 0 .4.4.4 1 0 1.4L5.4 4l1.8 1.8Z"/></svg>
+   </button>
+</div>
 
 <GroceryForm categoryId={category._id} />
 
-<ul>
+<ul class="grocery-list">
    {#each category.groceries as grocery (grocery.text)} <!-- distinguish by text as categories don't have an ID -->
    <Grocery categoryId={category._id} grocery={grocery.text}  />
  

--- a/imports/ui/CategoryForm.svelte
+++ b/imports/ui/CategoryForm.svelte
@@ -10,12 +10,12 @@ import { CategoriesCollection } from "../api/CategoriesCollection";
         newCategory = '';
     }
 </script>
-<form class='category-form' on:submit|preventDefault={handleSubmit}>
+<form class='wrapper-input' on:submit|preventDefault={handleSubmit}>
     <input 
     type='text' 
     name='text' 
     placeholder='Type to add a new category'
     bind:value={newCategory}
      />
-    <button type="submit">Add Category</button>
+    <button class="button-add" type="submit">Add Category</button>
 </form>

--- a/imports/ui/Grocery.svelte
+++ b/imports/ui/Grocery.svelte
@@ -9,6 +9,9 @@
    }
    </script>
 
-   <li> {grocery } 
-      <button class="delete" on:click={deleteGrocery} aria-label="Delete { grocery }">&times;</button>
+   <li class="grocery-list-item">
+      <span>{grocery}</span>
+      <button class="button-completed" on:click={deleteGrocery} aria-label="Delete { grocery }">
+         <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 8" width="9" height="8" fill="none"><path fill="#fff" d="M7.789.997c.84-.02 1.259.987.66 1.574l-4.28 4.28a.69.69 0 0 1-.965 0L1.032 4.67c-.902-.86.43-2.193 1.29-1.29L3.53 4.585c.084.084.23.084.325 0L7.16 1.28a.901.901 0 0 1 .63-.284Z"/></svg>
+      </button>
    </li> 

--- a/imports/ui/GroceryForm.svelte
+++ b/imports/ui/GroceryForm.svelte
@@ -12,12 +12,12 @@ import { CategoriesCollection } from "../api/CategoriesCollection";
         newGrocery = '';
     }
 </script>
-<form class='grocery-form' on:submit|preventDefault={handleSubmit}>
+<form class='wrapper-input margin-bottom-small' on:submit|preventDefault={handleSubmit}>
     <input 
     type='text' 
     name='text2' 
     placeholder='What is it you need?'
     bind:value={newGrocery}
      />
-    <button type="submit">Add to list</button>
+    <button class="button-add" type="submit">Add to list</button>
 </form>


### PR DESCRIPTION
This PR adds visual styling to the app. It also makes some slight adjustments to the markup to add and rename some classes declared on elements, as well as add SVG icons in some of the buttons.

`main.css` has been completely reworked. It uses a suite of CSS custom properties to allow for things like color and font size to be tweaked with more confidence about what is getting adjusted and where. All of these custom properties live at the top of the stylesheet in the `:root` selector. 

Visually, the app overall has a clean, minimal look. It uses a larger font size, with a bold sans-serif font for categories and the app title. The same font is used for the app header. The app header uses a darker blue color and the rest of the app content is on a white background. Categories have borders to communicate where each category starts and the previous ends. Grocery items are also inset slightly from the left to visually communicate they are child objects of a category.

Buttons have been assigned green color to create and red to destroy. The exception is the grocery item delete button, which uses a checkmark to indicate the item has been acquired. 

Text inputs now run the full width of the viewport, minus the width the add button takes up. Their size was also increased to make them easier touch targets.

The delete all button in the app header was also commented out. I felt it could easily be accidentally activated and could be dangerous considering there isn't a confirmation step before all content is destroyed in the app.